### PR TITLE
remove hard-coded functions names for `promisify`

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,11 +10,8 @@ const setTimeoutPromise = promisify(setTimeout);
 
 for (const [key, value] of Object.entries(fs)) {
 	if (key.includes('Sync')) continue;
-	if (`${key}Sync` in fs) {
-		exports[key] = promisify(value);
-	} else {
-		exports[key] = value;
-	}
+	if (`${key}Sync` in fs) exports[key] = promisify(value);
+	else exports[key] = value;
 }
 
 exports.copy = async (src, dest, options = {}) => {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,9 @@ for (const [key, value] of Object.entries(fs)) {
 	if (key.includes('Sync')) continue;
 	if (`${key}Sync` in fs) {
 		exports[key] = promisify(value);
-	} else exports[key] = value;
+	} else {
+		exports[key] = value;
+	}
 }
 
 exports.copy = async (src, dest, options = {}) => {

--- a/index.js
+++ b/index.js
@@ -4,27 +4,15 @@ const { promisify } = require('util');
 const { randomBytes } = require('crypto');
 const { tmpdir } = require('os');
 
-const targets = [
-	'access', 'appendFile',
-	'chmod', 'chown', 'close',
-	'fchmod', 'fchown', 'fdatasync', 'fstat', 'fsync', 'ftruncate', 'futimes',
-	'lchmod', 'lchown', 'link', 'lstat',
-	'mkdir', 'mkdtemp',
-	'open',
-	'read', 'readdir', 'readFile', 'readlink', 'realpath', 'rename', 'rmdir',
-	'stat', 'symlink',
-	'truncate',
-	'unlink', 'utimes',
-	'write', 'writeFile'
-];
 const o777 = 0o0777;
 const isWindows = process.platform === 'win32';
 const setTimeoutPromise = promisify(setTimeout);
 
 for (const [key, value] of Object.entries(fs)) {
 	if (key.includes('Sync')) continue;
-	if (targets.includes(key)) exports[key] = promisify(value);
-	else exports[key] = value;
+	if (`${key}Sync` in fs) {
+		exports[key] = promisify(value);
+	} else exports[key] = value;
 }
 
 exports.copy = async (src, dest, options = {}) => {


### PR DESCRIPTION
Removing hard coded array of functions from `fs` by promisifying every function that has `Sync` sibling