### PR TITLE
Scan

### DIFF
--- a/src/fs.js
+++ b/src/fs.js
@@ -54,6 +54,16 @@ for (const [key, value] of Object.entries(fs)) {
  */
 
 /**
+ * Identical to {@link https://nodejs.org/api/fs.html#fs_fs_copyfile_src_dest_flags_callback|fs.copyFile} but returns a promise instead.
+ * @function appendFile
+ * @memberof fsn/fs
+ * @param  {string|Buffer|URL} src File path to copy
+ * @param  {string|Buffer|URL} dest Destination to copy to
+ * @param  {number} [flags = 0] modifiers for copy operation.
+ * @return {Promise<void>}
+ */
+
+/**
  * Objects returned from {@link fsn/fs.watch|watch()} are of this type.
  * Identical to {@link https://nodejs.org/api/fs.html#fs_class_fs_fswatcher|fs.FSWatcher}.
  * @class FSWatcher

--- a/src/fs.js
+++ b/src/fs.js
@@ -55,7 +55,7 @@ for (const [key, value] of Object.entries(fs)) {
 
 /**
  * Identical to {@link https://nodejs.org/api/fs.html#fs_fs_copyfile_src_dest_flags_callback|fs.copyFile} but returns a promise instead.
- * @function appendFile
+ * @function copyFile
  * @memberof fsn/fs
  * @param  {string|Buffer|URL} src File path to copy
  * @param  {string|Buffer|URL} dest Destination to copy to

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ const nextra = {
 	readJSON: require('./nextra/readJSON'),
 	readJson: require('./nextra/readJSON'),
 	remove: require('./nextra/remove'),
+	scan: require('./nextra/scan'),
 	symlinkAtomic: require('./nextra/symlinkAtomic'),
 	writeFileAtomic: require('./nextra/writeFileAtomic'),
 	writeJSON: require('./nextra/writeJSON'),

--- a/src/nextra/scan.js
+++ b/src/nextra/scan.js
@@ -1,13 +1,13 @@
 const { resolve, join } = require('path');
 const { lstat, readdir } = require('../fs');
 
-module.exports = async function scan(root, limit) {
-	return getStat(resolve(root), new Map(), -1, limit);
+module.exports = async function scan(root, options) {
+	return getStat(resolve(root), new Map(), -1, options);
 };
 
-const getStat = async (dir, results, level, limit) => {
+const getStat = async (dir, results, level, options) => {
 	const stats = await lstat(dir);
-	results.set(dir, stats);
-	if (stats.isDirectory() && (typeof limit === 'undefined' || level < limit)) await Promise.all((await readdir(dir)).map(part => getStat(join(dir, part), results, ++level, limit)));
+	if (!options.filter || options.filter(stats)) results.set(dir, stats);
+	if (stats.isDirectory() && (typeof options.limit === 'undefined' || level < options.limit)) await Promise.all((await readdir(dir)).map(part => getStat(join(dir, part), results, ++level, limit)));
 	return results;
 };

--- a/src/nextra/scan.js
+++ b/src/nextra/scan.js
@@ -9,6 +9,6 @@ const getStat = async (dir, results, level, limit) => {
 	level++;
 	const stats = await lstat(dir);
 	results.set(dir, stats);
-	if (stats.isDirectory() && (typeof limit === 'undefined' || level < limit)) await Promise.all((await readdir(dir)).map(part => getStat(join(dir, part), results)));
+	if (stats.isDirectory() && (typeof limit === 'undefined' || level < limit)) await Promise.all((await readdir(dir)).map(part => getStat(join(dir, part), results, level, limit)));
 	return results;
 };

--- a/src/nextra/scan.js
+++ b/src/nextra/scan.js
@@ -1,13 +1,14 @@
 const { resolve, join } = require('path');
 const { lstat, readdir } = require('../fs');
 
-module.exports = async function scan(root) {
-	return getStat(resolve(root), new Map());
+module.exports = async function scan(root, limit) {
+	return getStat(resolve(root), new Map(), -1, limit);
 };
 
-const getStat = async (dir, results) => {
+const getStat = async (dir, results, level, limit) => {
+	level++;
 	const stats = await lstat(dir);
 	results.set(dir, stats);
-	if (stats.isDirectory()) await Promise.all((await readdir(dir)).map(part => getStat(join(dir, part), results)));
+	if (stats.isDirectory() && (!limit || level < limit)) await Promise.all((await readdir(dir)).map(part => getStat(join(dir, part), results)));
 	return results;
 };

--- a/src/nextra/scan.js
+++ b/src/nextra/scan.js
@@ -16,6 +16,6 @@ const { scanDeep } = require('../util');
  * @param  {scanOptions} [options = {}] The options for the scan
  * @return {Promise<Map<string, Stats>>}
  */
-module.exports = async function scan(root, options = {}) {
+module.exports = function scan(root, options = {}) {
 	return scanDeep(resolve(root), new Map(), -1, options);
 };

--- a/src/nextra/scan.js
+++ b/src/nextra/scan.js
@@ -1,13 +1,13 @@
 const { resolve, join } = require('path');
 const { lstat, readdir } = require('../fs');
 
-module.exports = async function scan(root, options) {
+module.exports = async function scan(root, options = {}) {
 	return getStat(resolve(root), new Map(), -1, options);
 };
 
 const getStat = async (dir, results, level, options) => {
 	const stats = await lstat(dir);
 	if (!options.filter || options.filter(stats)) results.set(dir, stats);
-	if (stats.isDirectory() && (typeof options.limit === 'undefined' || level < options.limit)) await Promise.all((await readdir(dir)).map(part => getStat(join(dir, part), results, ++level, limit)));
+	if (stats.isDirectory() && (typeof options.limit === 'undefined' || level < options.limit)) await Promise.all((await readdir(dir)).map(part => getStat(join(dir, part), results, ++level, options)));
 	return results;
 };

--- a/src/nextra/scan.js
+++ b/src/nextra/scan.js
@@ -1,13 +1,21 @@
-const { resolve, join } = require('path');
-const { lstat, readdir } = require('../fs');
+const { resolve } = require('path');
+const { scanDeep } = require('../util');
 
+/**
+ * @typedef {object} scanOptions
+ * @memberof fsn/nextra
+ * @property {Function} [filter] A filter function recieving (stats, path) to determin if the returned map should include a given entry
+ * @property {number} [depthLimit] How many directories deep the scan should go (0 is just the children of the passed root directory, no subdirectory files)
+ */
+
+/**
+ * Recursivly scans a directory, returning a map of stats keyed on the full path to the item.
+ * @function scan
+ * @memberof fsn/nextra
+ * @param  {string} root The path to scan
+ * @param  {scanOptions} [options = {}] The options for the scan
+ * @return {Promise<Map<string, Stats>>}
+ */
 module.exports = async function scan(root, options = {}) {
-	return getStat(resolve(root), new Map(), -1, options);
-};
-
-const getStat = async (dir, results, level, options) => {
-	const stats = await lstat(dir);
-	if (!options.filter || options.filter(stats)) results.set(dir, stats);
-	if (stats.isDirectory() && (typeof options.limit === 'undefined' || level < options.limit)) await Promise.all((await readdir(dir)).map(part => getStat(join(dir, part), results, ++level, options)));
-	return results;
+	return scanDeep(resolve(root), new Map(), -1, options);
 };

--- a/src/nextra/scan.js
+++ b/src/nextra/scan.js
@@ -6,9 +6,8 @@ module.exports = async function scan(root, limit) {
 };
 
 const getStat = async (dir, results, level, limit) => {
-	level++;
 	const stats = await lstat(dir);
 	results.set(dir, stats);
-	if (stats.isDirectory() && (typeof limit === 'undefined' || level < limit)) await Promise.all((await readdir(dir)).map(part => getStat(join(dir, part), results, level, limit)));
+	if (stats.isDirectory() && (typeof limit === 'undefined' || level < limit)) await Promise.all((await readdir(dir)).map(part => getStat(join(dir, part), results, ++level, limit)));
 	return results;
 };

--- a/src/nextra/scan.js
+++ b/src/nextra/scan.js
@@ -9,6 +9,6 @@ const getStat = async (dir, results, level, limit) => {
 	level++;
 	const stats = await lstat(dir);
 	results.set(dir, stats);
-	if (stats.isDirectory() && (!limit || level < limit)) await Promise.all((await readdir(dir)).map(part => getStat(join(dir, part), results)));
+	if (stats.isDirectory() && (typeof limit === 'undefined' || level < limit)) await Promise.all((await readdir(dir)).map(part => getStat(join(dir, part), results)));
 	return results;
 };

--- a/src/nextra/scan.js
+++ b/src/nextra/scan.js
@@ -1,0 +1,13 @@
+const { resolve, join } = require('path');
+const { lstat, readdir } = require('../fs');
+
+module.exports = async function scan(root) {
+	return getStat(resolve(root), new Map());
+};
+
+const getStat = async (dir, results) => {
+	const stats = await lstat(dir);
+	results.set(dir, stats);
+	if (stats.isDirectory()) await Promise.all((await readdir(dir)).map(part => getStat(join(dir, part), results)));
+	return results;
+};

--- a/src/util.js
+++ b/src/util.js
@@ -180,6 +180,15 @@ exports.isSrcKid = (src, dest) => {
 	}
 };
 
+exports.scanDeep = async (dir, results, level, options) => {
+	const stats = await lstat(dir);
+	if (!options.filter || options.filter(stats, dir)) results.set(dir, stats);
+	if (stats.isDirectory() && (typeof options.depthLimit === 'undefined' || level < options.depthLimit)) {
+		await Promise.all((await readdir(dir)).map(part => this.scanDeep(join(dir, part), results, ++level, options)));
+	}
+	return results;
+};
+
 exports.uuid = () => {
 	const id = randomBytes(32).toString('hex');
 	return (Array(32).join(0) + id).slice(-32).replace(/^.{8}|.{4}(?!$)/g, '$&-');

--- a/test/scan.js
+++ b/test/scan.js
@@ -1,0 +1,44 @@
+const ava = require('ava');
+const { tempFile, tempFileLoc, tempDir, tempDirLoc } = require('./lib');
+const nextra = require('../src');
+
+ava('file', async test => {
+	const file = tempFile();
+	const map = await nextra.scan(file);
+	await test.true(map.size === 1 && map.get(file).isFile());
+});
+
+ava('non-existant file', async test => {
+	await test.throws(nextra.scan(tempFileLoc()));
+});
+
+ava('empty directory', async test => {
+	const dir = tempDir();
+	const map = await nextra.scan(dir);
+	test.true(map.size === 1 && map.get(dir).isDirectory());
+});
+
+ava('full directory', async test => {
+	const dir = tempDir();
+	const file = tempFile(dir);
+	const map = await nextra.scan(dir, { filter: stats => stats.isFile() });
+	test.true(map.size === 1 && map.has(file));
+});
+
+ava('non-existant directory', async test => {
+	await test.throws(await nextra.scan(tempDirLoc()));
+});
+
+ava('deep directory', async test => {
+	const dir = tempDir();
+	const file = tempFile(tempDir(dir));
+	const map = await nextra.scan(dir, { filter: stats => stats.isFile() });
+	test.true(map.size === 1 && map.has(file));
+});
+
+ava('deep directory w/ limit', async test => {
+	const dir = tempDir();
+	const file = tempFile(tempDir(dir));
+	const map = await nextra.scan(dir, { filter: stats => stats.isFile(), depthLimit: 0 });
+	test.true(map.size === 0 && !map.has(file));
+});

--- a/test/scan.js
+++ b/test/scan.js
@@ -26,7 +26,7 @@ ava('full directory', async test => {
 });
 
 ava('non-existant directory', async test => {
-	await test.throws(await nextra.scan(tempDirLoc()));
+	await test.throws(nextra.scan(tempDirLoc()));
 });
 
 ava('deep directory', async test => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,6 +9,7 @@ declare module 'fs-nextra' {
 	export function chmod(path: string|Buffer|URL, mode?: number): Promise<void>;
 	export function chown(path: string|Buffer|URL, uid: number, gid: number): Promise<void>;
 	export function close(fd: number): Promise<void>;
+	export function copyFile(existingPath: string|Buffer|URL, newPath: string|Buffer|URL, flags?: number): Promise<void>;
 	export function createReadStream(path: string|Buffer|URL, options?: readStreamOptions|string): Promise<void>;
 	export function createWriteStream(path: string|Buffer|URL, options?: writeStreamOptions|string): Promise<void>;
 	export function exists(path: string|Buffer|URL): Promise<boolean>;
@@ -186,6 +187,7 @@ declare module 'fs-nextra' {
 	export function writeJSON(file: string, object: Object, options?: jsonOptions, atomic?: boolean): Promise<void>;
 	export function writeFileAtomic(file: string, data: string|Buffer|Uint8Array, options?: writeOptions|string): Promise<void>;
 	export function symlinkAtomic(source: string, destination: string, type?: SymLinkType): Promise<void>;
+	export function scan(path: string, options?: scanOptions): Promise<Map<string, Stats>>;
 	export function remove(path: string, options?: removeOptions): Promise<void>;
 	export function readJson(file: string, options?: readJSONOptions|string): Promise<Object>;
 	export function readJSON(file: string, options?: readJSONOptions|string): Promise<Object>;
@@ -249,6 +251,11 @@ declare module 'fs-nextra' {
 	};
 
 	export type SymLinkType = 'dir'|'file';
+
+	export type scanOptions = {
+		filter?: Function;
+		depthLimit?: number;
+	};
 
 	export type jsonOptions = {
 		replacer: Function;


### PR DESCRIPTION
Similar to Klaw, scan scans the file-system recursively. However doesn't use an event system to handle each detection. Instead returns a promise that resolves a map of lstats keyed on the full path.