### PR TITLE
chore(engines): Bump to 10.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "author": "BDISTIN",
   "license": "MIT",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=10.1.0"
   },
   "devDependencies": {
     "@types/node": "^10.1.3",


### PR DESCRIPTION
10.0.0 added fs/promises, but we use fs.promises, which is implemented in 10.1.0 ([10.1.0 changelog](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#2018-05-08-version-1010-current-mylesborins))