### PR TITLE
scripts: Add `prepublishOnly` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node.js native fs promises with next-generation extra methods.",
   "main": "dist/index.js",
   "scripts": {
-    "prepublishOnly": "yarn run build",
+    "prepublishOnly": "yarn build",
     "build": "tsc",
     "test": "yarn build && ava test/*.ts",
     "test:lint": "tslint '{test,src}/**/*.ts'",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Node.js native fs promises with next-generation extra methods.",
   "main": "dist/index.js",
   "scripts": {
+    "prepublishOnly": "yarn run build",
     "build": "tsc",
     "test": "yarn build && ava test/*.ts",
     "test:lint": "tslint '{test,src}/**/*.ts'",


### PR DESCRIPTION
This script runs before a package is published, removing any chance for the library to be published without being built first.

Sourced from the [official documentation](https://docs.npmjs.com/misc/scripts):

> **prepublishOnly**: Run BEFORE the package is prepared and packed, ONLY on npm publish.