### PR TITLE
fix #515: use resolved path for moving file 

### DIFF
--- a/src/nextra/move.ts
+++ b/src/nextra/move.ts
@@ -25,7 +25,9 @@ export interface MoveOptions {
  */
 export async function move(source: string, destination: string, options: MoveOptions = {}): Promise<void> {
 	const overwrite = options.overwrite || false;
-	if (resolve(source) === resolve(destination)) return fsp.access(source);
+	source = resolve(source)
+	destination = resolve(destination)
+	if (source === destination) return fsp.access(source);
 
 	const myStat = await fsp.lstat(source);
 	if (myStat.isDirectory() && isSrcKid(source, destination)) {


### PR DESCRIPTION
fix underlying problem that source directory is not a full path that might cause a cross-device link error